### PR TITLE
derived keys support for Post.py

### DIFF
--- a/deso/Derived.py
+++ b/deso/Derived.py
@@ -1,0 +1,13 @@
+from deso.Route import getRoute
+import requests
+from base58 import b58decode_check
+
+
+def addExtraData(transactionHex, derivedKey):
+    compressed_key = b58decode_check(derivedKey)[3:].hex()
+    payload = {"TransactionHex": transactionHex,
+               "ExtraData": {"DerivedPublicKey": compressed_key}}
+    endpoint = getRoute() + "append-extra-data"
+    res = requests.post(endpoint, json=payload)
+    TransactionHex = res.json()["TransactionHex"]
+    return TransactionHex

--- a/deso/Deso.py
+++ b/deso/Deso.py
@@ -6,9 +6,6 @@ import base58
 
 
 class Deso:
-    def __init__(self):
-        pass
-
     def __init__(self, PUBLIC_KEY=None, SEEDHEX=None, DERIVED_KEY=None):
         self.PUBLIC_KEY = PUBLIC_KEY
         self.SEEDHEX = SEEDHEX
@@ -40,8 +37,8 @@ class Deso:
         }
 
         if self.DERIVED_KEY:
-            # below this transaction fails
-            payload["MinFeeRateNanosPerKB"] = 12500
+            # below this transaction failed
+            payload["MinFeeRateNanosPerKB"] = 1250
 
         res = requests.post(endpoint, json=payload)
         TransactionHex = res.json()["TransactionHex"]

--- a/deso/Post.py
+++ b/deso/Post.py
@@ -1,19 +1,35 @@
+from os import PathLike
 import requests
 from deso.Route import getRoute
 from deso.Sign import Sign_Transaction
+from deso.Derived import addExtraData
 import binascii
 from ecdsa import SigningKey, SECP256k1
 from ecdsa.ecdsa import Public_key
 import jwt
 
 
-
 class Post:
-    def __init__(self, seedHex, publicKey):
+    def __init__(self, seedHex=None, publicKey=None):
         self.SEED_HEX = seedHex
         self.PUBLIC_KEY = publicKey
+        self.MIN_FEE = 1000
+
+    def useDerivedKey(self, publicKey, derivedKey, derivedSeedHex):
+        self.PUBLIC_KEY = publicKey
+        self.DERIVED_KEY = derivedKey
+        self.SEED_HEX = derivedSeedHex
+        # If using derived keys set min fee rate to 1250 bc transaction fails at default value
+        self.MIN_FEE = 1250
 
     def uploadImage(self, fileList):
+        # If the user passed the path to a simgle image, convert string into useable list
+        # I dont wanna make a list everytime I just want to upload a single image T_T
+        if type(fileList) == type("str"):
+            fileList = [
+                ('file', (fileList, open(
+                    fileList, "rb"), 'image/png'))
+            ]
         ROUTE = getRoute()
         private_key = bytes(self.SEED_HEX, 'utf-8')
         private_key = binascii.unhexlify(private_key)
@@ -24,11 +40,16 @@ class Post:
         endpointURL = ROUTE + "upload-image"
         payload = {'UserPublicKeyBase58Check': self.PUBLIC_KEY,
                    'JWT': encoded_jwt}
+        if self.DERIVED_KEY:
+            payload["UserPublicKeyBase58Check"] = self.DERIVED_KEY
         response = requests.request(
             "POST", endpointURL, data=payload, files=fileList)
         return response.json()
 
     def send(self, content, imageUrl=[], postExtraData={}):
+        # if user passed url for a single image as string, convert str into list[str]
+        if type(imageUrl) == type("str"):
+            imageUrl = [imageUrl]
         header = {
             "content-type": "application/json"
         }
@@ -42,12 +63,15 @@ class Post:
                    "PostExtraData": postExtraData,
                    "Sub": "",
                    "IsHidden":  False,
-                   "MinFeeRateNanosPerKB": 1000
+                   "MinFeeRateNanosPerKB": self.MIN_FEE
                    }
         ROUTE = getRoute()
         endpointURL = ROUTE + "submit-post"
         res = requests.post(endpointURL, json=payload, headers=header)
         transactionHex = res.json()["TransactionHex"]
+
+        if self.DERIVED_KEY:
+            transactionHex = addExtraData(transactionHex, self.DERIVED_KEY)
 
         signedTransactionHex = Sign_Transaction(
             self.SEED_HEX, transactionHex
@@ -56,8 +80,10 @@ class Post:
         submitPayload = {"TransactionHex": signedTransactionHex}
         endpointURL = ROUTE + "submit-transaction"
         submitResponse = requests.post(endpointURL, json=submitPayload)
-        # returns 200
-        return {"status": submitResponse.status_code, "postHashHex": submitResponse.json()["TxnHashHex"]}
+        if submitResponse.status_code == 200:
+            return {"status": submitResponse.status_code, "postHashHex": submitResponse.json()["TxnHashHex"]}
+        else:
+            return submitResponse.json()
 
     def mint(self, postHashHex, minBidDeSo,  copy=1, creatorRoyality=5, coinHolderRoyality=10, isForSale=True):
         ROUTE = getRoute()
@@ -69,9 +95,14 @@ class Post:
                    "NFTRoyaltyToCoinBasisPoints": round(coinHolderRoyality*100),
                    "HasUnlockable": False,
                    "IsForSale": isForSale, "MinBidAmountNanos": round(minBidDeSo * 1e9),
-                   "MinFeeRateNanosPerKB": 1000}
+                   "MinFeeRateNanosPerKB": self.MIN_FEE}
+
         response = requests.post(endpointURL, json=payload)
         transactionHex = response.json()["TransactionHex"]
+
+        if self.DERIVED_KEY:
+            transactionHex = addExtraData(transactionHex, self.DERIVED_KEY)
+
         signedTransactionHex = Sign_Transaction(
             self.SEED_HEX, transactionHex
         )  # txn signature
@@ -88,10 +119,14 @@ class Post:
         payload = {"ReaderPublicKeyBase58Check": self.PUBLIC_KEY,
                    "LikedPostHashHex": postHashHex,
                    "IsUnlike": not isLike,
-                   "MinFeeRateNanosPerKB": 1000}
+                   "MinFeeRateNanosPerKB": self.MIN_FEE}
 
         response = requests.post(endpointURL, json=payload)
         transactionHex = response.json()["TransactionHex"]
+
+        if self.DERIVED_KEY:
+            transactionHex = addExtraData(transactionHex, self.DERIVED_KEY)
+
         signedTransactionHex = Sign_Transaction(
             self.SEED_HEX, transactionHex
         )  # txn signature

--- a/deso/Sign.py
+++ b/deso/Sign.py
@@ -2,103 +2,113 @@
 import hashlib
 import hmac
 
+
 def get_hmac(key, data):
-	return hmac.new(key, data, hashlib.sha256).digest()
+    return hmac.new(key, data, hashlib.sha256).digest()
+
 
 def hmac_drbg(entropy, string):
-	material = entropy + string
-	K = b"\x00" * 32
-	V = b"\x01" * 32
+    material = entropy + string
+    K = b"\x00" * 32
+    V = b"\x01" * 32
 
-	K = get_hmac(K, V + b"\x00" + material)
-	V = get_hmac(K, V)
-	K = get_hmac(K, V + b"\x01" + material)
-	V = get_hmac(K, V)
+    K = get_hmac(K, V + b"\x00" + material)
+    V = get_hmac(K, V)
+    K = get_hmac(K, V + b"\x01" + material)
+    V = get_hmac(K, V)
 
-	temp = b""
-	while len(temp) < 32:
-		V = get_hmac(K, V)
-		temp += V
+    temp = b""
+    while len(temp) < 32:
+        V = get_hmac(K, V)
+        temp += V
 
-	return temp[:32]
+    return temp[:32]
 
 #######
 
-g=(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
-	0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8)
-p=0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
+
+g = (0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
+     0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8)
+p = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
 n = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 
+
 def point_add(point1, point2):
-	# Returns the result of point1 + point2 according to the group law.
-	if point1 is None:
-		return point2
-	if point2 is None:
-		return point1
+    # Returns the result of point1 + point2 according to the group law.
+    if point1 is None:
+        return point2
+    if point2 is None:
+        return point1
 
-	x1, y1 = point1
-	x2, y2 = point2
+    x1, y1 = point1
+    x2, y2 = point2
 
-	if x1 == x2 and y1 != y2:
-		return None
+    if x1 == x2 and y1 != y2:
+        return None
 
-	if x1 == x2:
-		m = (3 * x1 * x1) * pow(2 * y1, -1, p)
-	else:
-		m = (y1 - y2) * pow(x1 - x2, -1, p)
+    if x1 == x2:
+        m = (3 * x1 * x1) * pow(2 * y1, -1, p)
+    else:
+        m = (y1 - y2) * pow(x1 - x2, -1, p)
 
-	x3 = m * m - x1 - x2
-	y3 = y1 + m * (x3 - x1)
-	result = (x3 % p, -y3 % p)
+    x3 = m * m - x1 - x2
+    y3 = y1 + m * (x3 - x1)
+    result = (x3 % p, -y3 % p)
 
-	return result
+    return result
+
 
 def scalar_mult(k, point):
-	# Returns k * point computed using the double and point_add algorithm.
-	result = None
-	addend = point
+    # Returns k * point computed using the double and point_add algorithm.
+    result = None
+    addend = point
 
-	while k:
-		if k & 1:
-			# Add.
-			result = point_add(result, addend)
-		# Double.
-		addend = point_add(addend, addend)
-		k >>= 1
+    while k:
+        if k & 1:
+            # Add.
+            result = point_add(result, addend)
+        # Double.
+        addend = point_add(addend, addend)
+        k >>= 1
 
-	return result
+    return result
 
 #######
 
-def to_DER(r, s): # Signature to DER format
-	r = bytes.fromhex(r)
-	s = bytes.fromhex(s)
-	if r[0] >= 0x80:
-		r = bytes.fromhex("00")+r
-	if s[0] >= 0x80:
-		s = bytes.fromhex("00")+s
-	res = bytes.fromhex("02"+hex(len(r))[2:]) + r + bytes.fromhex("02"+hex(len(s))[2:]) + s
-	res = bytes.fromhex("30"+hex(len(res))[2:]) + res
 
-	return res.hex()
+def to_DER(r, s):  # Signature to DER format
+    r = bytes.fromhex(r)
+    s = bytes.fromhex(s)
+    if r[0] >= 0x80:
+        r = bytes.fromhex("00")+r
+    if s[0] >= 0x80:
+        s = bytes.fromhex("00")+s
+    res = bytes.fromhex("02"+hex(len(r))[2:]) + \
+        r + bytes.fromhex("02"+hex(len(s))[2:]) + s
+    res = bytes.fromhex("30"+hex(len(res))[2:]) + res
+
+    return res.hex()
+
 
 def hexify(n):
-	n = hex(n)[2:]
-	if len(n)%2 != 0:
-		n = "0"+n
-	return n
+    n = hex(n)[2:]
+    if len(n) % 2 != 0:
+        n = "0"+n
+    return n
 
 
 def Sign_Transaction(seedHex, TransactionHex):
-	s256 = hashlib.sha256(hashlib.sha256(bytes.fromhex(TransactionHex)).digest()).digest()
-	drbg = hmac_drbg(entropy=bytes.fromhex(seedHex), string=s256)
-	k = int.from_bytes(drbg, 'big')
-	kp = scalar_mult(k, g)
-	kpX = kp[0]
-	r = kpX % n
-	s = pow(k, -1, n) * (r * int(seedHex, 16)+int(s256.hex(), 16))
-	s = s % n
-	signature = to_DER(hexify(r), hexify(s))
-	signed_transaction = TransactionHex[:-2] + hex(len(bytearray.fromhex(signature)))[2:] + signature
-	
-	return signed_transaction
+    s256 = hashlib.sha256(hashlib.sha256(
+        bytes.fromhex(TransactionHex)).digest()).digest()
+    drbg = hmac_drbg(entropy=bytes.fromhex(seedHex), string=s256)
+    k = int.from_bytes(drbg, 'big')
+    kp = scalar_mult(k, g)
+    kpX = kp[0]
+    r = kpX % n
+    s = pow(k, -1, n) * (r * int(seedHex, 16)+int(s256.hex(), 16))
+    s = s % n
+    signature = to_DER(hexify(r), hexify(s))
+    signed_transaction = TransactionHex[:-2] + \
+        hex(len(bytearray.fromhex(signature)))[2:] + signature
+
+    return signed_transaction


### PR DESCRIPTION
Derived keys can now be used to upload images and send posts on DeSo

- No need to pass in a `list[tuple]` when uploading a single image, you can just pass the path to image as a string **(Only when uploading a single image)**
- Can just pass the `ImageURL` string from `post.uploadImage` to `post.send` instead of a `list[str]` **(Only when uploading a single image)**
- Users can use derived keys to make posts by using `post.useDerivedKey()`

Example code :

```py
from deso.Post import Post

post = Post() # pass nothing here if using derived key
post.useDerivedKey(PUBKEY, DERIVED_KEY, DERIVED_SEED)

url = post.uploadImage("Filepath.png")["ImageURL"]
r = post.send("derived key test", imageUrl=url)
```