### PR TITLE
fixed derived key bug in post.py

### DIFF
--- a/deso/Post.py
+++ b/deso/Post.py
@@ -14,6 +14,7 @@ class Post:
         self.SEED_HEX = seedHex
         self.PUBLIC_KEY = publicKey
         self.MIN_FEE = 1000
+        self.DERIVED_KEY = None
 
     def useDerivedKey(self, publicKey, derivedKey, derivedSeedHex):
         self.PUBLIC_KEY = publicKey


### PR DESCRIPTION
bugfix: Post.py functions tried to find `DERIVED_KEY` when using normal seed hex