### PR TITLE
Update to enforce low-s for signature

### DIFF
--- a/deso/Sign.py
+++ b/deso/Sign.py
@@ -144,6 +144,28 @@ def Sign_Transaction(seedHex, TransactionHex):
     r = kpX % n
     s = inverse_mod(k, n) * (r * int(seedHex, 16) + int(s256.hex(), 16))
     s = s % n
+    def Sign_Transaction(seedHex, TransactionHex):
+    s256 = hashlib.sha256(
+        hashlib.sha256(bytes.fromhex(TransactionHex)).digest()
+    ).digest()
+    drbg = hmac_drbg(entropy=bytes.fromhex(seedHex), string=s256)
+    k = int.from_bytes(drbg, "big")
+    kp = scalar_mult(k, g)
+    kpX = kp[0]
+    r = kpX % n
+    s = inverse_mod(k, n) * (r * int(seedHex, 16) + int(s256.hex(), 16))
+    s = s % n
+    # Enforce low-s
+    if s > n // 2:
+        s = n - s
+    signature = to_DER(hexify(r), hexify(s))
+    signed_transaction = (
+        TransactionHex[:-2]
+        + hex(len(bytearray.fromhex(signature)))[2:]
+        + signature
+    )
+
+    return signed_transaction
     signature = to_DER(hexify(r), hexify(s))
     signed_transaction = (
         TransactionHex[:-2]


### PR DESCRIPTION
DeSo now requires a low-s for a signature to be valid.