### PR TITLE
Add: optional accountNumber to getSeedHexFromSeedPhrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,13 @@ print(desoPosts.getNFTBidsForNFTPost(postHashHex).json())
 
 To perform all the WRITE actions to DeSo Blockchain you need SEED_HEX and DESO Public Key.
 
-This is how you generate SEED_HEX using your 12 word mnemonic phrase.
+This is how you generate SEED_HEX using your 12 word mnemonic phrase and account number (optional).
 
 ```python
 from deso import Identity
 SEED_PHRASE = 'YOUR 12 WORD DESO SEED PHRASE'
-SEED_HEX = Identity.getSeedHexFromSeedPhrase(SEED_PHRASE)
+ACCOUNT_NUMBER = 0
+SEED_HEX = Identity.getSeedHexFromSeedPhrase(SEED_PHRASE, ACCOUNT_NUMBER)
 print(SEED_HEX)
 ```
 

--- a/deso/Identity.py
+++ b/deso/Identity.py
@@ -65,9 +65,11 @@ class Identity:
         return seedPhrase
     # Credit to @Nathanwells on DeSo for this function
 
-    def getSeedHexFromSeedPhrase(seedPhrase):
-        '''Returns the seedHex of  a seedPhrase'''
+    # Credit to @10XChris on DeSo for accountNumber functionality
+    # Referenced from: https://github.com/deso-protocol/deso-offline-tool/blob/7e0e216ef8e134626751c80ecf0f5e9c5995db3c/src/ts/components/sign-form.ts#L388C21-L388C25
+    def getSeedHexFromSeedPhrase(seedPhrase, accountNumber=0):
+        '''Returns the seedHex of a seedPhrase and account number (optional)'''
         hdwallet = HDWallet(symbol=BTC)
         hdwallet.from_mnemonic(mnemonic=seedPhrase, passphrase=None)
-        hdwallet.from_path(path='m/44\'/0\'/0\'/0/0')
+        hdwallet.from_path(path='m/44\'/0\'/'+str(accountNumber)+'\'/0/0')
         return hdwallet.private_key()


### PR DESCRIPTION
A Seed Phrase can have 1 or more Account Numbers. The default is "0". You can now pass an optional Account Number into Identity.getSeedHexFromSeedPhrase(seedPhrase, accountNumber=0)

Inspired by: https://offline.deso.com/#sign