### PR TITLE
Update Social.py - uploadToArweave needs "self"

### DIFF
--- a/deso/Social.py
+++ b/deso/Social.py
@@ -485,7 +485,7 @@ class Social:
         except Exception as e:
             raise Exception(error["error"])
 
-    def uploadToArweave(wallet, image):
+    def uploadToArweave(self, wallet, image):
         wallet = arweave.Wallet(wallet)
         with open(image, "rb", buffering=0) as file_handler:
             tx = Transaction(


### PR DESCRIPTION
Instance methods should take a "self" parameter (pyright-extended).
Without this I can't pass "wallet" as a param when calling the function.